### PR TITLE
Add challenge set instructions page

### DIFF
--- a/src/routes/(authenticated)/challenge-set/[id]/+page.server.ts
+++ b/src/routes/(authenticated)/challenge-set/[id]/+page.server.ts
@@ -1,0 +1,67 @@
+import prisma from '$lib/prisma';
+import { error, invalid, redirect } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import getActionChallengeSet from './getActionChallengeSet';
+
+export const load: PageServerLoad = async ({ params, parent }) => {
+	const now = new Date();
+	const { user } = await parent();
+	const id = parseInt(params.id);
+
+	const challengeSet = await prisma.challengeSet.findUnique({
+		where: { id },
+		include: {
+			challengeSetResponses: {
+				where: { playerId: user.id },
+				select: { startedAt: true, completedAt: true }
+			},
+			challenges: {
+				select: { id: true }
+			}
+		}
+	});
+	if (!challengeSet || !challengeSet.timeAvailableStart || challengeSet.timeAvailableStart > now) {
+		throw error(404, 'Challenge set not found');
+	}
+	return { challengeSet };
+};
+
+export const actions: Actions = {
+	/**
+	 * This is called when the user clicks to start or continue a challenge set.
+	 */
+	default: async ({ locals, params }) => {
+		const userId = locals.user?.id;
+		const id = parseInt(params.id);
+
+		// if the user is not logged in, redirect to login (unlikely but possible)
+		if (!userId) throw redirect(403, '/login');
+
+		// get the challenge set from the database and add getters used below
+		const challengeSet = await getActionChallengeSet(id, userId);
+
+		// if the challenge set doesn't exist or is not available, throw a 404
+		if (!challengeSet || !challengeSet.isAvailable)
+			return invalid(404, { error: 'Challenge set not found' });
+
+		// if the challenge set has no challenges, throw a 404
+		if (!challengeSet.challengesExist)
+			return invalid(404, { error: 'Challenge set has no challenges' });
+
+		// if the user has already completed the challenge set, redirect to the results page
+		if (challengeSet.userHasCompleted) throw redirect(302, challengeSet.resultsUrl);
+
+		// if the user has not started the challenge set, create a new challenge set response
+		// with the current time as the start time
+		if (!challengeSet.userResponseExists) {
+			const now = new Date();
+			await prisma.challengeSetResponse.create({
+				data: { challengeSetId: id, playerId: userId, startedAt: now }
+			});
+		}
+
+		// redirect to the first incomplete challenge in the challenge set, if it exists, or
+		// the first challenge if it doesn't
+		throw redirect(302, `/challenge-set/${id}/challenge/${challengeSet.nextChallenge.id}`);
+	}
+};

--- a/src/routes/(authenticated)/challenge-set/[id]/+page.svelte
+++ b/src/routes/(authenticated)/challenge-set/[id]/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import type { PageData, ActionData } from './$types';
+
+	export let data: PageData;
+	export let form: ActionData;
+
+	const { id, title, instructions, challengeSetResponses } = data.challengeSet;
+	const { startedAt, completedAt } = challengeSetResponses[0] ?? {};
+	const userHasStartedChallengeSet = !!startedAt;
+	const userHasCompletedChallengeSet = !!completedAt;
+	const reviewUrl = `/challenge-set/${id}/review`;
+</script>
+
+{#if userHasCompletedChallengeSet}
+	<h1 class="text-4xl mt-4 mb-1">Instructions</h1>
+	<p>Challenge complete! Click below to review your answers.</p>
+	<h2 class="text-2xl mt-4 mb-1">{title}</h2>
+	<p>{@html instructions}</p>
+	<a href={reviewUrl}>Review</a>
+{:else}
+	<h1 class="text-4xl mt-4 mb-1">Instructions</h1>
+	<p>Read the instructions with care and hit start when you are ready.</p>
+	<h2 class="text-2xl mt-4 mb-1">{title}</h2>
+	<p>{@html instructions}</p>
+	<form method="POST">
+		<button type="submit" class="bg-green-700 text-white font-bold my-8 py-3 px-6 rounded">
+			{userHasStartedChallengeSet ? 'CONTINUE' : 'START'}
+		</button>
+	</form>
+{/if}
+{#if form?.error}
+	<div
+		class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+		role="alert"
+	>
+		<span class="block sm:inline">{form.error}</span>
+	</div>
+{/if}

--- a/src/routes/(authenticated)/challenge-set/[id]/getActionChallengeSet.ts
+++ b/src/routes/(authenticated)/challenge-set/[id]/getActionChallengeSet.ts
@@ -1,0 +1,100 @@
+import prisma from '$lib/prisma';
+
+type RetrievedChallengeSet = NonNullable<Awaited<ReturnType<typeof getDbChallengeSet>>>;
+
+const getDbChallengeSet = async (id: number, userId: number) => {
+	const challengeSet = await prisma.challengeSet.findUnique({
+		where: { id },
+		select: {
+			id: true,
+			timeAvailableStart: true,
+			challengeSetResponses: {
+				where: { playerId: userId },
+				select: { startedAt: true, completedAt: true }
+			},
+			challenges: {
+				select: {
+					id: true,
+					responses: { select: { response: true }, where: { playerId: userId } }
+				},
+				orderBy: { id: 'asc' }
+			}
+		}
+	});
+	return challengeSet;
+};
+
+class ActionChallengeSet {
+	id: number;
+	timeAvailableStart: Date | null;
+	challengeSetResponses: {
+		startedAt: Date | null;
+		completedAt: Date | null;
+	}[];
+	challenges: {
+		id: number;
+		responses: {
+			response: string;
+		}[];
+	}[];
+
+	constructor(private challengeSet: RetrievedChallengeSet) {
+		this.id = challengeSet.id;
+		this.timeAvailableStart = challengeSet.timeAvailableStart;
+		this.challengeSetResponses = challengeSet.challengeSetResponses;
+		this.challenges = challengeSet.challenges;
+	}
+
+	/**
+	 * Does the challenge set have a start time and has it past?
+	 */
+	get isAvailable() {
+		return Boolean(this.timeAvailableStart && this.timeAvailableStart < new Date());
+	}
+
+	/**
+	 * Does the challenge set have any challenges?
+	 */
+	get challengesExist() {
+		return Boolean(this.challenges?.length);
+	}
+
+	get userHasCompleted() {
+		return Boolean(this.challengeSetResponses[0]?.completedAt);
+	}
+
+	/**
+	 * Url for the results page for this challenge set
+	 */
+	get resultsUrl() {
+		return `/challenge-set/${this.id}/results`;
+	}
+
+	get userResponseExists() {
+		return Boolean(this.challengeSetResponses.length);
+	}
+
+	/**
+	 * The first challenge that the user has not completed, if one exists.
+	 * The first challenge otherwise.
+	 */
+	get nextChallenge() {
+		const firstIncompleteChallenge = this.challenges.find(
+			(challenge) => !challenge.responses.length
+		);
+		const nextChallenge = firstIncompleteChallenge || this.challenges[0];
+		return nextChallenge;
+	}
+
+	get nextChallengeUrl() {
+		return `/challenge-set/${this.id}/challenge/${this.nextChallenge.id}`;
+	}
+}
+
+const getActionChallengeSet = async (id: number, userId: number) => {
+	const challengeSet = await getDbChallengeSet(id, userId);
+	if (!challengeSet) return null;
+	return new ActionChallengeSet(challengeSet);
+};
+
+export default getActionChallengeSet;


### PR DESCRIPTION
Adds the challenge set instructions page, including possible user actions (most often, starting the challenge set).

I made a design decision for this PR that I'm not entirely happy with:

I'm using a class specifically for the `ChallengeSet`s returned here, rather than the one in the `$lib/prisma` folder. There's a real trade-off here. This local class is able to include type-safe getters based on the value it receives, which includes only and all selected fields.

To use a more general ChallengeSet class will require either:
1. Always fetching the full object, including any relations, or
2. Treating all properties as optional if they ever might not be fetched. In this case, typescript type-checking is greatly limited. Each method will have to check to make sure the properties it uses are in the object received. Even then it can only throw a runtime error rather than having compile-time safety. And I haven't found a way to distinguish a property that returns undefined from one that was not retrieved.

I'm not happy about either of those two, so at least for now this page's action has its own class. That answer probably doesn't scale, but it's what I've got for now.